### PR TITLE
Add an option to only show errors in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ import WebpackJsdomTapePlugin from "webpack-jsdom-tape-plugin"
 
 ## api
 
-### func WebpackJsdomTapePlugin({ string: url, string: entry, bool: exit = true})
+### func WebpackJsdomTapePlugin({ string: url, string: entry, bool: exit = true, bool: errorsOnly = false})
 
 creates a test runner for when the given `entry`, at the given `url`.
 
@@ -22,6 +22,8 @@ when the test is done, process exits with 0 if passed, and 1 if any errors occur
 `exit` option allow you to change this behavior of this plugin.
 Note that using `exit: false` might introduce a memory leak since jsdom might
 not clean everything properly.
+
+`errorsOnly` option allow to only show tests on error allowing clean ouput.
 
 
 ## test example
@@ -90,6 +92,7 @@ export default {
       // NOTE HERE THAT YOU WILL NEED AN ENTRY THAT SHOULD BE "tests"
       // to be sure a "tests.js" is in the assets list
       exit: false,
+      errorsOnly: false,
     })
   ]
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,10 +2,10 @@ import jsdom from "jsdom"
 import tape from "tape-catch"
 import chalk from "chalk"
 
-export default ({ url, entry, exit = true }) =>
+export default ({ url, entry, exit = true, errorsOnly = false }) =>
   function(compilation) {
     this.plugin("done", ({ compilation }) => test({
-      compilation, url, entry, exit
+      compilation, url, entry, exit, errorsOnly
     }))
   }
 
@@ -15,7 +15,7 @@ const hasError =
 const isOk =
   (item) => item.includes("# pass") || item.trim().indexOf("ok") === 0
 
-const test = ({ compilation, url, entry, exit }) => {
+const test = ({ compilation, url, entry, exit, errorsOnly }) => {
   jsdom.env({
     url: url,
     src: entry.map((e) => {
@@ -33,6 +33,9 @@ const test = ({ compilation, url, entry, exit }) => {
         if(hasError(chunk)) {
           console.log(chalk.red(chunk.trim()))
           return
+        }
+        if(errorsOnly) {
+            return
         }
         if(isOk(chunk)) {
           console.log(chalk.green("✔︎") + " " + chalk.gray(chunk.trim()))


### PR DESCRIPTION
We have hundreds of tests and it's hard to find tests on error.
With this option we only want to show invalid tests.
